### PR TITLE
Upgrade to `@httptoolkit/osx-find-executable` 2.x

### DIFF
--- a/lib/detect/darwin.js
+++ b/lib/detect/darwin.js
@@ -2,11 +2,12 @@
 
 const path = require('path')
 const plist = require('simple-plist')
-const osxFindExecutable = require('@httptoolkit/osx-find-executable')
+const { fromPromise } = require('catering')
+const { findExecutableById } = require('@httptoolkit/osx-find-executable')
 
 function finder (bundleId, versionKey) {
   return function find (callback) {
-    osxFindExecutable(bundleId, function (err, execPath) {
+    fromPromise(findExecutableById(bundleId), function (err, execPath) {
       // Ignore not found error
       if (err) return callback()
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@httptoolkit/osx-find-executable": "^1.1.0",
+    "@httptoolkit/osx-find-executable": "^2.0.0",
+    "catering": "^2.1.1",
     "debug": "^4.2.0",
     "headless-support": "^1.0.0",
     "simple-plist": "^1.1.1",


### PR DESCRIPTION
The previous version emits an npm-audit warning, for the change at https://github.com/httptoolkit/osx-find-executable/commit/20fb1e2c, which is a breaking change that can't be patched downstream as it is incompatible with the current way the function is called.

It appears this repo has no tests.

Test plan:

* `node -e "require('./index.js').detect(console.log)"` before/after the change, no difference in output.